### PR TITLE
feat: update validate reporter to include status prefix everywhere

### DIFF
--- a/app/src/main/kotlin/me/frmr/github/repopolicy/app/ConsolePolicyValidationReporter.kt
+++ b/app/src/main/kotlin/me/frmr/github/repopolicy/app/ConsolePolicyValidationReporter.kt
@@ -9,7 +9,6 @@ object ConsolePolicyValidationReporter : PolicyValidationReporter {
   override fun report(results: List<PolicyValidationResult>): Int {
     var fails = 0
     results.groupBy { it.subject }.forEach { (subject, results) ->
-      println("Results for $subject")
 
       results.forEach { result ->
         val prefix = if (result.passed) {
@@ -19,10 +18,12 @@ object ConsolePolicyValidationReporter : PolicyValidationReporter {
           "[ FAIL ]"
         }
 
+        println("$prefix Results for $subject")
         println("$prefix ${result.description}")
 
         if (! result.extra.isNullOrBlank()) {
-          println("         " + result.extra)
+//          println("         " + result.extra)
+          println("$prefix ${result.extra}")
         }
       }
 

--- a/app/src/main/kotlin/me/frmr/github/repopolicy/app/ConsolePolicyValidationReporter.kt
+++ b/app/src/main/kotlin/me/frmr/github/repopolicy/app/ConsolePolicyValidationReporter.kt
@@ -22,7 +22,6 @@ object ConsolePolicyValidationReporter : PolicyValidationReporter {
         println("$prefix ${result.description}")
 
         if (! result.extra.isNullOrBlank()) {
-//          println("         " + result.extra)
           println("$prefix ${result.extra}")
         }
       }


### PR DESCRIPTION
Fixes #16 

Now output is like so:
```
[ PASS ] Results for organization/repo1
[ PASS ] Default branch is main

[ FAIL ] Results for organization/repo1/main
[ FAIL ] Branch protection rules do not match policy
[ FAIL ] Missing required checks; Dismiss stale reviews disabled; Require branch up to date is disabled; Code owner reviews are not required; Requires 1 reviews, should require 2; Review dismissal restrictions missing

[ PASS ] Results for organization/repo2
[ PASS ] Default branch is main

[ PASS ] Results for organization/repo2/main
[ PASS ] Branch protection matches policy
```