### PR TITLE
refactor: allow required reviews to be the minimum

### DIFF
--- a/core/src/main/kotlin/me/frmr/github/repopolicy/core/operators/branch/BranchProtectionOperator.kt
+++ b/core/src/main/kotlin/me/frmr/github/repopolicy/core/operators/branch/BranchProtectionOperator.kt
@@ -92,7 +92,7 @@ class BranchProtectionOperator(
         }
       }
 
-      if (requiredReviewCount != null && protectionDetails.requiredReviews?.requiredReviewers != requiredReviewCount) {
+      if (requiredReviewCount != null && protectionDetails.requiredReviews?.requiredReviewers!! < requiredReviewCount) {
         val currentRequiredReviewers = protectionDetails.requiredReviews?.requiredReviewers
         problems.add("Requires $currentRequiredReviewers reviews, should require $requiredReviewCount")
       }

--- a/core/src/test/kotlin/me/frmr/github/repopolicy/core/operators/branch/BranchProtectionOperatorTest.kt
+++ b/core/src/test/kotlin/me/frmr/github/repopolicy/core/operators/branch/BranchProtectionOperatorTest.kt
@@ -372,7 +372,7 @@ class BranchProtectionOperatorTest {
   }
 
   @Test
-  fun failsOnRequiredReviewCountMismatch() {
+  fun failsOnRequiredReviewCountIsLessThanDesired() {
     val result1 = runValidate(
       desiredEnabled = true,
       currentEnabled = true,
@@ -396,6 +396,17 @@ class BranchProtectionOperatorTest {
     assertThat(result1.passed).isTrue
   }
 
+  @Test
+  fun passesOnRequiredReviewCountIsGreaterThanDesired() {
+    val result1 = runValidate(
+            desiredEnabled = true,
+            currentEnabled = true,
+            desiredRequiredReviewCount = 1,
+            currentRequiredReviewCount = 2,
+    )
+
+    assertThat(result1.passed).isTrue
+  }
   @Test
   fun failsOnRestrictReviewDismissalsMismatch() {
     val result1 = runValidate(


### PR DESCRIPTION
For example, do not fail if a repo requires 2 reviews, but the policy only requires 1. 