### PR TITLE
fix: handle not found exception when removing branch protection

### DIFF
--- a/core/src/main/kotlin/me/frmr/github/repopolicy/core/operators/branch/BranchProtectionOperator.kt
+++ b/core/src/main/kotlin/me/frmr/github/repopolicy/core/operators/branch/BranchProtectionOperator.kt
@@ -177,7 +177,11 @@ class BranchProtectionOperator(
     }
 
     // Disable protection on this branch first
-    ghBranch.disableProtection()
+    try {
+      ghBranch.disableProtection()
+    } catch (e: GHFileNotFoundException) {
+      null
+    }
 
     // Rebuild protection based on the policy
     var protectionBuilder = ghBranch.enableProtection()


### PR DESCRIPTION
The enforce command would throw `File Not Found` error if the branch protection did not exist.