### PR TITLE
feat: add authenticate as github app as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,47 @@ docker build -t repo-policy .
 ```
 
 ## Usage
+If you're running as a part of an
+automated process it is **STRONGLY** recommended to run that action in
+the validate mode and only use enforce for those cases where you know
+you want to make the changes to the repository.
+
+### Authentication
 
 The Repo Policy Utility requires GitHub authentication to be set in environment
-variables. The following environment variables are needed:
+variables. There are two options: 1) Authenticating via OAuth or 2) Authenticating as a GitHub App
+
+#### OAuth
+
+To authenticate via OAuth, define the following environment variables:
 
 |Name           | Required | Description                              |
 |---------------|----------|------------------------------------------|
 |GITHUB_OAUTH   |Y         |The access token for the utility to use.  |
 |GITHUB_ENDPOINT|N         |API Endpoint to use if using Enterprise.  |
 
-With these environment variables defined you can run the utility in either
-**validate mode** or **enforce mode**. If you're running as a part of an
-automated process it is **STRONGLY** recommended to run that action in
-the validate mode and only use enforce for those cases where you know
-you want to make the changes to the repository.
+#### GitHub App
+
+Create and Install a GitHub app
+
+1. Create a GitHub app in your organization.
+2. Install the app into the GitHub organization.
+3. Generate a private key.
+4. Convert the private key to DER format and Base64 encode.
+    ```shell
+    openssl pkcs8 -topk8 -inform PEM -outform DER -in PATH_TO_PEM_FILE -out PATH_TO_DER_FILE -nocrypt
+    base64 PATH_TO_DER_FILE
+    ```
+
+To authenticate as a GitHub App, define the following environment variables:
+
+| Name                        | Required | Description                                       |
+|-----------------------------|----------|---------------------------------------------------|
+| GITHUB_APP_KEY              |Y         | App private key in DER format, BASE64 encoded.    |
+| GITHUB_APP_ID               |Y         | GitHub app ID.                                    |
+| GITHUB_APP_INSTALLATION_ORG |Y         | The organization name where the app is installed. |
+| GITHUB_ENDPOINT             |N         | API Endpoint to use if using Enterprise.          |
+
 
 ### Validate Mode
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,6 +9,9 @@ dependencies {
     implementation("com.charleskorn.kaml:kaml:0.26.0")
     implementation("org.kohsuke:github-api:1.129")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.1")
+    compileOnly("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.11.5")
     testImplementation("io.mockk:mockk:1.10.6")
 }
 

--- a/core/src/main/kotlin/me/frmr/github/repopolicy/core/PolicyEngine.kt
+++ b/core/src/main/kotlin/me/frmr/github/repopolicy/core/PolicyEngine.kt
@@ -11,7 +11,7 @@ import org.kohsuke.github.*
 import java.security.Key
 import java.security.KeyFactory
 import java.security.spec.PKCS8EncodedKeySpec
-import java.util.*
+import java.util.Date
 
 
 /**

--- a/core/src/main/kotlin/me/frmr/github/repopolicy/core/PolicyEngine.kt
+++ b/core/src/main/kotlin/me/frmr/github/repopolicy/core/PolicyEngine.kt
@@ -1,13 +1,18 @@
 package me.frmr.github.repopolicy.core
 
 import com.charleskorn.kaml.Yaml
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.io.Decoders
 import me.frmr.github.repopolicy.core.model.*
 import me.frmr.github.repopolicy.core.parser.PolicyDataFile
 import me.frmr.github.repopolicy.core.parser.PolicyParser
-import org.kohsuke.github.GHRepository
-import org.kohsuke.github.GitHub
-import org.kohsuke.github.GitHubBuilder
-import org.kohsuke.github.PagedSearchIterable
+import org.kohsuke.github.*
+import java.security.Key
+import java.security.KeyFactory
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.*
+
 
 /**
  * A *policy engine* consumes a *policy description* and validates that
@@ -24,24 +29,58 @@ class PolicyEngine(val policy: PolicyDescription, val logging: Boolean) {
   /**
    * Init the GitHub Client from environment variables. Specifically:
    *
-   * - GITHUB_LOGIN
    * - GITHUB_OAUTH
+   * - GITHUB_APP_KEY
+   * - GITHUB_APP_ID
+   * - GITHUB_APP_INSTALLATION_ORG
    * - GITHUB_ENDPOINT (for enterprise server installs)
    */
   fun initGithubClient() {
-    this.githubClient = GitHubBuilder.fromEnvironment().build()
+    if (System.getenv("GITHUB_OAUTH") != null) {
+      this.githubClient = GitHubBuilder.fromEnvironment().build()
+    } else if (System.getenv("GITHUB_APP_KEY") != null && System.getenv("GITHUB_APP_ID") != null) {
+      // Authenticating as a GitHub App via JWT token
+      // https://github-api.kohsuke.org/githubappjwtauth.html
+      val jwtToken: String = this.createJWT()
+      this.githubClient = GitHubBuilder().withJwtToken(jwtToken).build()
+
+      // Authenticating as an installation via App Installation Token
+      // https://github-api.kohsuke.org/githubappappinsttokenauth.html
+      val appInstallation: GHAppInstallation = this.githubClient.getApp().getInstallationByOrganization(System.getenv("GITHUB_APP_INSTALLATION_ORG")) // Installation Id
+      val appInstallationToken = appInstallation.createToken().create().token
+
+      this.githubClient = GitHubBuilder().withAppInstallationToken(appInstallationToken).build()
+    }
   }
 
   /**
-   * Variation on initGithubClient that can inject a totally custom
-   * github client.
+   * Generate the JWT to Authenticating as a GitHub App
    */
-  fun initGithubClient(github: GitHub) {
-    this.githubClient = github
+  @Throws(Exception::class)
+  fun createJWT(): String {
+    val signatureAlgorithm: SignatureAlgorithm = SignatureAlgorithm.RS256 // must use RS256
+
+    //  Get the base64 encoded private key and use it to sign the JWT
+    val keyBytes: ByteArray = Decoders.BASE64.decode(System.getenv("GITHUB_APP_KEY"))
+    val spec = PKCS8EncodedKeySpec(keyBytes)
+    val keyFactory: KeyFactory = KeyFactory.getInstance("RSA")
+    val signingKey: Key = keyFactory.generatePrivate(spec)
+
+    val nowMillis = System.currentTimeMillis() - 30000 // rollback 30s to allow for clock drift
+    val issuedAt = Date(nowMillis)
+    val ttlMillis = nowMillis + 600000 // GitHub's JWT expiration time has 10m maximum
+    val expiration = Date(ttlMillis)
+
+    return Jwts.builder()
+            .setIssuedAt(issuedAt)
+            .setIssuer(System.getenv("GITHUB_APP_ID")) // use the GitHub App's ID as the value for the JWT issuer claim
+            .signWith(signingKey, signatureAlgorithm)
+            .setExpiration(expiration)
+            .compact()
   }
 
   private fun findMatchingRepos(subject: PolicySubjectMatchers): PagedSearchIterable<GHRepository>? {
-    var searchRequest = githubClient.searchRepositories()
+    val searchRequest = githubClient.searchRepositories()
 
     var q = ""
 


### PR DESCRIPTION
This adds the option to authenticate as a GitHub app and documentation addressing how to do so.