### PR TITLE
chore: shorten app installation token timeout

### DIFF
--- a/core/src/main/kotlin/me/frmr/github/repopolicy/core/PolicyEngine.kt
+++ b/core/src/main/kotlin/me/frmr/github/repopolicy/core/PolicyEngine.kt
@@ -55,7 +55,7 @@ class PolicyEngine(val policy: PolicyDescription, val logging: Boolean) {
         .getInstallationByOrganization(System.getenv("GITHUB_APP_INSTALLATION_ORG")) // Installation Id
       val appInstallationToken = appInstallation.createToken().create().token
 
-      this.appInstallationTokenTtl = System.currentTimeMillis() + 3540000 // refresh in 59 minutes
+      this.appInstallationTokenTtl = System.currentTimeMillis() + 270000 // refresh in 45 minutes
 
       this.githubClient = GitHubBuilder().withAppInstallationToken(appInstallationToken).build()
     }


### PR DESCRIPTION
Shorten app installation token timeout from 59 minutes to 45 minutes